### PR TITLE
Copy files only once for startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Simple rollup plugin to copy files.
 
+## Usage
+
+**NB:** This plugin only copies files once when rollup start, any later changes will not be copied (before you start rollup again).
+
 ```js
+import copyPlugin from 'rollup-copy-plugin';
+
 export default {
   // ...
   plugins: [

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,32 @@
-import fs from 'fs';
+/* eslint-disable no-console */
+import { createReadStream, createWriteStream } from 'fs';
 
 export default function copy(options = {}) {
-  const copyFiles = () => {
-    Object.keys(options).forEach((src) => {
-      // eslint-disable-next-line no-console
-      console.log(`copy: ${options[src]} > ${src}`);
-      fs.writeFileSync(options[src], fs.readFileSync(src));
+  const copyFile = (source, target) => {
+    const rd = createReadStream(source);
+    const wr = createWriteStream(target);
+    return new Promise(((resolve, reject) => {
+      rd.on('error', reject);
+      wr.on('error', reject);
+      wr.on('finish', resolve);
+      console.log(`copy: ${source} > ${target}`);
+      rd.pipe(wr);
+    })).catch((error) => {
+      rd.destroy();
+      wr.end();
+      console.log(`copy-error: ${source} > ${target}`);
+      throw error;
     });
   };
 
+  let started = false;
   return {
-    ongenerate() {
-      return copyFiles();
+    name: 'copy',
+    ongenerate: () => {
+      if (!started) {
+        started = true;
+        Object.keys(options).forEach(src => copyFile(src, options[src]));
+      }
     },
   };
 }


### PR DESCRIPTION
## What does this pull request do?

Closes #1 

Plugin now copyes files once when plugin starts and ignores them after that (rollup will probably not watch those files anyway). Also added note to readme about it.

Files are now moved using pipeing in async mode, no more sync mode usage as before. 

/cc @vladshcherbin